### PR TITLE
Add NC_ env variables to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,13 @@ To use an external SMTP server, you have to provide the connection details. To c
 
 Check the [Nextcloud documentation](https://docs.nextcloud.com/server/15/admin_manual/configuration_server/email_configuration.html) for other values to configure SMTP.
 
+## Overriding config.php parameters
+
+You can also override parameters from the `config.php` file by defining an `NC_` prefixed environment variable. Example:
+- `NC_skeletondirectory`: Overrides `skeletondirectory`, the directory where the skeleton files are located.
+
+Parameter list is available in the [Nextcloud documentation](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html).
+
 # Running this image with docker-compose
 The easiest way to get a fully featured and functional setup is using a `docker-compose` file. There are too many different possibilities to setup your system, so here are only some examples of what you have to look for.
 


### PR DESCRIPTION
I was looking for a way to override `config.php` configuation with env variables. I've spend some time looking around to find out that it's possible with `NC_` prefixed variables, but it wasn't specified in the doc. Found the information in this PR: https://github.com/nextcloud/server/pull/3966